### PR TITLE
fix: import parser properly delegates to resource location parser

### DIFF
--- a/bolt/parse.py
+++ b/bolt/parse.py
@@ -268,7 +268,7 @@ def get_bolt_parsers(
         ),
         "bolt:import": AlternativeParser(
             [
-                ImportLocationConstraint(parsers["resource_location_or_tag"]),
+                ImportLocationConstraint(delegate("resource_location_or_tag")),
                 parse_python_import,
             ]
         ),

--- a/bolt/parse.py
+++ b/bolt/parse.py
@@ -268,7 +268,9 @@ def get_bolt_parsers(
         ),
         "bolt:import": AlternativeParser(
             [
-                ImportLocationConstraint(delegate("resource_location_or_tag")),
+                ImportLocationConstraint(
+                    DisableInterpolationParser(delegate("resource_location_or_tag"))
+                ),
                 parse_python_import,
             ]
         ),


### PR DESCRIPTION
I noticed that the `bolt:import` parser uses `parsers["resource_location_or_tag"]` to get the `resource_location_or_tag` parser (instead of using the `delegate` function), making it impossible to be overridden.